### PR TITLE
Introduce Optionality Tracker: FastAPI + SQLite backend and React frontend with income model & analytics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,9 @@
-awakening.mid
-emotional_heatmap.png
+__pycache__/
+*.pyc
+*.sqlite3
+backend/.venv/
+backend/optionality_tracker.db
+frontend/node_modules/
+frontend/dist/
+
+frontend/*.tsbuildinfo

--- a/README.md
+++ b/README.md
@@ -1,53 +1,85 @@
-# ClarionCodexEnv
-Vibe coding stuff
+# Optionality Tracker
 
-## Fractal Awakening Symphony
+Income-focused tracker with FastAPI + SQLite backend and React + TypeScript frontend.
 
-`fractal_awakening.py` generates a MIDI file and emotional heatmap based on a fractal logistic map.
+## Pre-implementation notes
 
-### Usage
+### 1) Brief plan (files)
+1. Backend model/settings and deterministic readiness computation (`backend/app/models.py`, `backend/app/income_model.py`, `backend/app/schemas.py`, `backend/app/main.py`, `backend/app/analytics.py`).
+2. Frontend dashboard + income model editor UI (`frontend/src/pages/DashboardPage.tsx`, `frontend/src/pages/IncomeModelPage.tsx`, `frontend/src/api.ts`, `frontend/src/types.ts`, `frontend/src/App.tsx`).
+3. Tests + docs (`backend/tests/test_income_model.py`, `README.md`).
 
-1. Install dependencies:
+### 2) Income Target Model definition
+Variables:
+- Capitals in `[0..1]`: Skill `S`, Network `N`, Lead `L`, Energy stability `E`.
+- Weights: `w_s`, `w_n`, `w_l`, `w_e` (sum to `1.0`).
+- Half-life: `half_life_days` for decay.
+- Target daily income default: `$200`.
 
-   ```bash
-   pip install midiutil matplotlib
-   ```
+Core formulas:
+- `decay(days_ago) = 0.5^(days_ago / half_life_days)`
+- `S = 1 - exp(-2.0 * S_raw)` where `S_raw` from decayed positive `(H,E)` signal.
+- `N = 1 - exp(-0.6 * N_raw)` from decayed network exposure events.
+- `L = 1 - exp(-0.7 * L_raw)` from decayed lead exposure events.
+- `E_raw` from decayed `E` score mapped to `[0..1]`; apply variance penalty.
+- `Readiness = 100 * clamp01(w_s*S + w_n*N + w_l*L + w_e*E)`.
+- `confidence = clamp01(log(1 + days_with_any_logs)/log(31))`.
 
-2. Run the generator:
+Defaults:
+- `target_daily_income=200`, weights `0.25` each, `half_life_days=21`, `exposure_goal_per_week=5`.
 
-   ```bash
-   python fractal_awakening.py
-   ```
+### 3) API changes
+New:
+- `GET /api/income-model/settings`
+- `PUT /api/income-model/settings`
+- `GET /api/income-model/series?start=YYYY-MM-DD&end=YYYY-MM-DD`
 
-   This creates:
+Updated:
+- `GET /api/analytics/summary` now includes `readiness_latest`, `capitals_latest`, `confidence_latest`.
 
-   - `awakening.mid` — the fractal crescendo
-   - `emotional_heatmap.png` — visual map of confusion → resonance → recognition → being
-   - `emotional_heatmap.csv` — raw data for the heatmap
-
-   The `.mid` and `.png` files are generated outputs and are ignored by version control.
-   Run the script whenever you need fresh copies.
-
-3. Open `awakening.mid` in MuseScore to shape the final *Awakening* score.
-
-## Decentralized AI Ecosystem Simulator
-
-`ecosystem_sim.py` simulates a decentralized AI research ecosystem as a dynamical system with adaptive coupling and shock events.
-
-### Usage
-
+Examples:
 ```bash
-pip install numpy matplotlib
-python ecosystem_sim.py --run-sweep
+curl http://localhost:8000/api/income-model/settings
+
+curl -X PUT http://localhost:8000/api/income-model/settings \
+  -H "Content-Type: application/json" \
+  -d '{
+    "target_daily_income": 200,
+    "w_s": 0.35,
+    "w_n": 0.20,
+    "w_l": 0.30,
+    "w_e": 0.15,
+    "half_life_days": 21,
+    "exposure_goal_per_week": 5
+  }'
+
+curl "http://localhost:8000/api/income-model/series?start=2026-01-01&end=2026-01-31"
 ```
 
-Optional interactive tuning:
+### 4) UI changes
+- Dashboard: added “Target Readiness” KPI (+ confidence), readiness trend chart, and capital breakdown panel.
+- New page “Income Model”: edit target and weights with auto-rebalancing sliders, half-life and exposure goal controls, live readiness preview.
 
+## Run locally
+
+### Backend
 ```bash
-python ecosystem_sim.py --interactive
+cd backend
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+uvicorn app.main:app --reload
 ```
 
-Outputs are written to `outputs/` by default:
-- `trajectory.png`
-- `phase_omega.png`
-- `phase_class.png` (when `--run-sweep` is used)
+### Frontend
+```bash
+cd frontend
+npm install
+npm run dev
+```
+
+### Tests
+```bash
+cd backend
+pytest -q
+```

--- a/backend/app/analytics.py
+++ b/backend/app/analytics.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+from collections import defaultdict
+from datetime import date, timedelta
+from typing import Iterable
+
+from .models import Action, Exposure
+from .schemas import AnalyticsSummary, AnalyticsTotals, CapitalsLatest, DailyAnalyticsPoint, WeeklyExposurePoint
+
+
+def _date_span(start: date, end: date) -> list[date]:
+    day_count = (end - start).days + 1
+    return [start + timedelta(days=offset) for offset in range(day_count)]
+
+
+def compute_summary(
+    actions: Iterable[Action],
+    exposures: Iterable[Exposure],
+    start: date,
+    end: date,
+    readiness_latest: float = 0.0,
+    capitals_latest: CapitalsLatest | None = None,
+    confidence_latest: float = 0.0,
+) -> AnalyticsSummary:
+    days = _date_span(start, end)
+
+    by_day_o_delta: dict[date, int] = defaultdict(int)
+    by_day_neg_delta: dict[date, int] = defaultdict(int)
+    by_day_irreversibility_values: dict[date, list[float]] = defaultdict(list)
+
+    for action in actions:
+        day = action.occurred_at.date()
+        by_day_o_delta[day] += action.o_delta
+        by_day_neg_delta[day] += min(0, action.o_delta)
+        by_day_irreversibility_values[day].append(float(2 - action.r))
+
+    daily: list[DailyAnalyticsPoint] = []
+    cumulative = 0
+    for idx, day in enumerate(days):
+        day_o_delta = by_day_o_delta[day]
+        cumulative += day_o_delta
+        window_days = days[max(0, idx - 6) : idx + 1]
+        constraint_debt = sum(by_day_neg_delta[d] for d in window_days)
+        iv = by_day_irreversibility_values.get(day, [])
+        irreversibility_avg = sum(iv) / len(iv) if iv else 0.0
+        daily.append(
+            DailyAnalyticsPoint(
+                date=day,
+                o_delta_sum=day_o_delta,
+                cumulative=cumulative,
+                constraint_debt_7d=constraint_debt,
+                irreversibility_avg=round(irreversibility_avg, 2),
+            )
+        )
+
+    weekly_counts: dict[date, int] = defaultdict(int)
+    for exposure in exposures:
+        exp_day = exposure.occurred_at.date()
+        week_start = exp_day - timedelta(days=exp_day.weekday())
+        weekly_counts[week_start] += 1
+
+    weekly_exposure = [
+        WeeklyExposurePoint(week_start=week_start, count=count)
+        for week_start, count in sorted(weekly_counts.items())
+        if start <= week_start <= end or start <= week_start + timedelta(days=6) <= end
+    ]
+
+    sum_o_delta = sum(point.o_delta_sum for point in daily)
+    totals = AnalyticsTotals(
+        sum_o_delta=sum_o_delta,
+        avg_o_delta=round(sum_o_delta / len(daily), 2) if daily else 0.0,
+        constraint_debt_7d_last=daily[-1].constraint_debt_7d if daily else 0,
+        exposure_count_period=sum(point.count for point in weekly_exposure),
+        readiness_latest=round(readiness_latest, 2),
+        capitals_latest=capitals_latest or CapitalsLatest(),
+        confidence_latest=round(confidence_latest, 4),
+    )
+    return AnalyticsSummary(totals=totals, daily=daily, weekly_exposure=weekly_exposure)

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import DeclarativeBase, sessionmaker
+
+DATABASE_URL = "sqlite:///./optionality_tracker.db"
+
+
+class Base(DeclarativeBase):
+    pass
+
+
+engine = create_engine(DATABASE_URL, connect_args={"check_same_thread": False})
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()

--- a/backend/app/income_model.py
+++ b/backend/app/income_model.py
@@ -1,0 +1,164 @@
+from __future__ import annotations
+
+import math
+from collections import defaultdict
+from dataclasses import dataclass
+from datetime import date, datetime, timedelta
+from typing import Iterable
+
+from .models import Action, Exposure, IncomeModelSettings
+
+NETWORK_TYPES = {"outreach", "interview", "proposal", "post", "portfolio_update"}
+LEAD_TYPES = {"application", "outreach", "proposal", "post"}
+ENERGY_DOMAINS = {"sleep", "nutrition", "movement", "stress"}
+
+
+@dataclass
+class IncomePoint:
+    date: date
+    s: float
+    n: float
+    l: float
+    e: float
+    readiness: float
+    confidence: float
+    low_data_confidence: bool
+
+
+def clamp01(value: float) -> float:
+    return max(0.0, min(1.0, value))
+
+
+def decay_factor(days_ago: int, half_life_days: int) -> float:
+    return 0.5 ** (days_ago / max(1, half_life_days))
+
+
+def saturate(raw: float, k: float) -> float:
+    return clamp01(1 - math.exp(-k * max(0.0, raw)))
+
+
+def _daterange(start: date, end: date) -> list[date]:
+    return [start + timedelta(days=i) for i in range((end - start).days + 1)]
+
+
+def _weighted_avg(values: list[tuple[float, float]]) -> float:
+    if not values:
+        return 0.0
+    num = sum(v * w for v, w in values)
+    den = sum(w for _, w in values)
+    return num / den if den else 0.0
+
+
+def _variance(values: list[float]) -> float:
+    if len(values) < 2:
+        return 0.0
+    mean = sum(values) / len(values)
+    return sum((x - mean) ** 2 for x in values) / len(values)
+
+
+def get_or_create_settings(db, now: datetime | None = None) -> IncomeModelSettings:
+    settings = db.get(IncomeModelSettings, 1)
+    if settings:
+        return settings
+    settings = IncomeModelSettings(
+        id=1,
+        target_daily_income=200,
+        w_s=0.25,
+        w_n=0.25,
+        w_l=0.25,
+        w_e=0.25,
+        half_life_days=21,
+        exposure_goal_per_week=5,
+        updated_at=now or datetime.utcnow(),
+    )
+    db.add(settings)
+    db.commit()
+    db.refresh(settings)
+    return settings
+
+
+def compute_income_series(
+    actions: Iterable[Action],
+    exposures: Iterable[Exposure],
+    start: date,
+    end: date,
+    settings: IncomeModelSettings,
+    window_days: int = 60,
+) -> list[IncomePoint]:
+    actions_list = list(actions)
+    exposures_list = list(exposures)
+    all_days = _daterange(start, end)
+
+    points: list[IncomePoint] = []
+    for day in all_days:
+        window_start = day - timedelta(days=window_days - 1)
+
+        skill_weighted: list[tuple[float, float]] = []
+        network_raw = 0.0
+        lead_raw = 0.0
+        energy_weighted: list[tuple[float, float]] = []
+        energy_daily: dict[date, list[float]] = defaultdict(list)
+        days_with_any_logs: set[date] = set()
+
+        for a in actions_list:
+            ad = a.occurred_at.date()
+            if ad < window_start or ad > day:
+                continue
+            days_ago = (day - ad).days
+            decay = decay_factor(days_ago, settings.half_life_days)
+            days_with_any_logs.add(ad)
+
+            skill_contrib = clamp01((max(0, a.h) + max(0, a.e)) / 4)
+            skill_weighted.append((skill_contrib, decay))
+
+            energy_signal = clamp01((a.e + 2) / 4)
+            energy_weighted.append((energy_signal, decay))
+            energy_daily[ad].append(energy_signal)
+
+        for ex in exposures_list:
+            ed = ex.occurred_at.date()
+            if ed < window_start or ed > day:
+                continue
+            days_ago = (day - ed).days
+            decay = decay_factor(days_ago, settings.half_life_days)
+            days_with_any_logs.add(ed)
+            et = ex.type.lower().strip()
+            if et in NETWORK_TYPES:
+                network_raw += decay
+            if et in LEAD_TYPES:
+                lead_raw += decay
+
+        s_raw = _weighted_avg(skill_weighted)
+        s = saturate(s_raw, 2.0)
+        n = saturate(network_raw, 0.6)
+        l = saturate(lead_raw, 0.7)
+
+        e_raw = _weighted_avg(energy_weighted)
+        daily_energy_means = [sum(vs) / len(vs) for vs in energy_daily.values()]
+        var_penalty = clamp01(_variance(daily_energy_means) / 0.05)
+        e = clamp01(e_raw * (1 - 0.5 * var_penalty))
+
+        low_data = len(days_with_any_logs) < 5
+        if low_data:
+            s = s if s > 0 else 0.5
+            n = n if n > 0 else 0.5
+            l = l if l > 0 else 0.5
+            e = e if e > 0 else 0.5
+
+        readiness = 100 * clamp01(settings.w_s * s + settings.w_n * n + settings.w_l * l + settings.w_e * e)
+        confidence = clamp01(math.log(1 + len(days_with_any_logs)) / math.log(1 + 30))
+
+        points.append(
+            IncomePoint(
+                date=day,
+                s=round(s, 4),
+                n=round(n, 4),
+                l=round(l, 4),
+                e=round(e, 4),
+                readiness=round(readiness, 2),
+                confidence=round(confidence, 4),
+                low_data_confidence=low_data,
+            )
+        )
+
+    return points

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,0 +1,266 @@
+from __future__ import annotations
+
+from datetime import date, datetime, timedelta
+
+from fastapi import Depends, FastAPI, HTTPException, Query
+from fastapi.middleware.cors import CORSMiddleware
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from .analytics import compute_summary
+from .database import Base, engine, get_db
+from .income_model import compute_income_series, get_or_create_settings
+from .models import Action, Exposure
+from .schemas import (
+    ActionCreate,
+    ActionRead,
+    ActionUpdate,
+    AnalyticsSummary,
+    CapitalsLatest,
+    ExposureCreate,
+    ExposureRead,
+    IncomeModelSeriesResponse,
+    IncomeModelSettingsRead,
+    IncomeModelSettingsUpdate,
+    IncomeModelPoint,
+    SeedResponse,
+)
+
+Base.metadata.create_all(bind=engine)
+
+app = FastAPI(title="Optionality Tracker API", version="0.2.0")
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["http://localhost:5173"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+
+@app.get("/health")
+def health() -> dict[str, str]:
+    return {"status": "ok"}
+
+
+@app.post("/api/actions", response_model=ActionRead)
+def create_action(payload: ActionCreate, db: Session = Depends(get_db)) -> Action:
+    action = Action(
+        occurred_at=payload.occurred_at,
+        domain=payload.domain,
+        title=payload.title,
+        notes=payload.notes,
+        h=payload.h,
+        r=payload.r,
+        d=payload.d,
+        e=payload.e,
+        o_delta=payload.h + payload.r - payload.d + payload.e,
+        tags=payload.tags,
+    )
+    db.add(action)
+    db.commit()
+    db.refresh(action)
+    return action
+
+
+@app.get("/api/actions", response_model=list[ActionRead])
+def list_actions(
+    start: date | None = Query(default=None),
+    end: date | None = Query(default=None),
+    limit: int = Query(default=100, ge=1, le=500),
+    offset: int = Query(default=0, ge=0),
+    db: Session = Depends(get_db),
+):
+    query = select(Action)
+    if start:
+        query = query.where(Action.occurred_at >= datetime.combine(start, datetime.min.time()))
+    if end:
+        query = query.where(Action.occurred_at < datetime.combine(end + timedelta(days=1), datetime.min.time()))
+    return list(db.scalars(query.order_by(Action.occurred_at.desc()).limit(limit).offset(offset)).all())
+
+
+@app.get("/api/actions/{action_id}", response_model=ActionRead)
+def get_action(action_id: int, db: Session = Depends(get_db)) -> Action:
+    action = db.get(Action, action_id)
+    if not action:
+        raise HTTPException(status_code=404, detail="Action not found")
+    return action
+
+
+@app.put("/api/actions/{action_id}", response_model=ActionRead)
+def update_action(action_id: int, payload: ActionUpdate, db: Session = Depends(get_db)) -> Action:
+    action = db.get(Action, action_id)
+    if not action:
+        raise HTTPException(status_code=404, detail="Action not found")
+    for field in ["occurred_at", "domain", "title", "notes", "h", "r", "d", "e", "tags"]:
+        setattr(action, field, getattr(payload, field))
+    action.o_delta = payload.h + payload.r - payload.d + payload.e
+    db.commit()
+    db.refresh(action)
+    return action
+
+
+@app.delete("/api/actions/{action_id}")
+def delete_action(action_id: int, db: Session = Depends(get_db)) -> dict[str, bool]:
+    action = db.get(Action, action_id)
+    if not action:
+        raise HTTPException(status_code=404, detail="Action not found")
+    db.delete(action)
+    db.commit()
+    return {"deleted": True}
+
+
+@app.post("/api/exposures", response_model=ExposureRead)
+def create_exposure(payload: ExposureCreate, db: Session = Depends(get_db)) -> Exposure:
+    exposure = Exposure(occurred_at=payload.occurred_at, type=payload.type, notes=payload.notes)
+    db.add(exposure)
+    db.commit()
+    db.refresh(exposure)
+    return exposure
+
+
+@app.get("/api/exposures", response_model=list[ExposureRead])
+def list_exposures(
+    start: date | None = Query(default=None),
+    end: date | None = Query(default=None),
+    db: Session = Depends(get_db),
+):
+    query = select(Exposure)
+    if start:
+        query = query.where(Exposure.occurred_at >= datetime.combine(start, datetime.min.time()))
+    if end:
+        query = query.where(Exposure.occurred_at < datetime.combine(end + timedelta(days=1), datetime.min.time()))
+    return list(db.scalars(query.order_by(Exposure.occurred_at.desc())).all())
+
+
+@app.delete("/api/exposures/{exposure_id}")
+def delete_exposure(exposure_id: int, db: Session = Depends(get_db)) -> dict[str, bool]:
+    exposure = db.get(Exposure, exposure_id)
+    if not exposure:
+        raise HTTPException(status_code=404, detail="Exposure not found")
+    db.delete(exposure)
+    db.commit()
+    return {"deleted": True}
+
+
+@app.get("/api/income-model/settings", response_model=IncomeModelSettingsRead)
+def get_income_model_settings(db: Session = Depends(get_db)):
+    return get_or_create_settings(db)
+
+
+@app.put("/api/income-model/settings", response_model=IncomeModelSettingsRead)
+def update_income_model_settings(payload: IncomeModelSettingsUpdate, db: Session = Depends(get_db)):
+    total = payload.w_s + payload.w_n + payload.w_l + payload.w_e
+    if abs(total - 1.0) > 1e-3:
+        raise HTTPException(status_code=400, detail="weights must sum to 1.0")
+    settings = get_or_create_settings(db)
+    for field in ["target_daily_income", "w_s", "w_n", "w_l", "w_e", "half_life_days", "exposure_goal_per_week"]:
+        setattr(settings, field, getattr(payload, field))
+    settings.updated_at = datetime.utcnow()
+    db.commit()
+    db.refresh(settings)
+    return settings
+
+
+@app.get("/api/income-model/series", response_model=IncomeModelSeriesResponse)
+def income_model_series(
+    start: date | None = Query(default=None),
+    end: date | None = Query(default=None),
+    db: Session = Depends(get_db),
+):
+    end_date = end or date.today()
+    start_date = start or (end_date - timedelta(days=29))
+    if end_date < start_date:
+        raise HTTPException(status_code=400, detail="end must be on or after start")
+
+    settings = get_or_create_settings(db)
+    fetch_start = datetime.combine(start_date - timedelta(days=59), datetime.min.time())
+    fetch_end = datetime.combine(end_date + timedelta(days=1), datetime.min.time())
+    actions = list(db.scalars(select(Action).where(Action.occurred_at >= fetch_start, Action.occurred_at < fetch_end)).all())
+    exposures = list(db.scalars(select(Exposure).where(Exposure.occurred_at >= fetch_start, Exposure.occurred_at < fetch_end)).all())
+
+    points = compute_income_series(actions, exposures, start_date, end_date, settings)
+    daily = [IncomeModelPoint(**p.__dict__) for p in points]
+    explanations = [
+        "S uses decayed positive H and E from actions, then saturation.",
+        "N uses decayed network-oriented exposures: outreach/interview/proposal/post/portfolio_update.",
+        "L uses decayed lead-oriented exposures: application/outreach/proposal/post.",
+        "E uses decayed E score signal with variance penalty for stability.",
+    ]
+    return IncomeModelSeriesResponse(
+        daily=daily,
+        current=daily[-1] if daily else None,
+        settings=IncomeModelSettingsRead.model_validate(settings),
+        explanations=explanations,
+    )
+
+
+@app.get("/api/analytics/summary", response_model=AnalyticsSummary)
+def analytics_summary(
+    start: date | None = Query(default=None),
+    end: date | None = Query(default=None),
+    db: Session = Depends(get_db),
+) -> AnalyticsSummary:
+    end_date = end or date.today()
+    start_date = start or (end_date - timedelta(days=29))
+    if end_date < start_date:
+        raise HTTPException(status_code=400, detail="end must be on or after start")
+
+    start_dt = datetime.combine(start_date, datetime.min.time())
+    end_dt = datetime.combine(end_date + timedelta(days=1), datetime.min.time())
+    actions = list(db.scalars(select(Action).where(Action.occurred_at >= start_dt, Action.occurred_at < end_dt)).all())
+    exposures = list(db.scalars(select(Exposure).where(Exposure.occurred_at >= start_dt, Exposure.occurred_at < end_dt)).all())
+
+    settings = get_or_create_settings(db)
+    income_points = compute_income_series(actions, exposures, start_date, end_date, settings)
+    latest = income_points[-1] if income_points else None
+    capitals = CapitalsLatest(s=latest.s, n=latest.n, l=latest.l, e=latest.e) if latest else CapitalsLatest()
+    return compute_summary(
+        actions=actions,
+        exposures=exposures,
+        start=start_date,
+        end=end_date,
+        readiness_latest=latest.readiness if latest else 0.0,
+        capitals_latest=capitals,
+        confidence_latest=latest.confidence if latest else 0.0,
+    )
+
+
+@app.post("/api/dev/seed", response_model=SeedResponse)
+def seed_demo_data(db: Session = Depends(get_db)) -> SeedResponse:
+    now = datetime.utcnow()
+    domains = ["income", "sleep", "nutrition", "movement", "stress", "social"]
+    exposure_types = ["application", "outreach", "post", "proposal", "interview", "portfolio_update"]
+
+    for i in range(20):
+        h = (i % 5) - 2
+        r = ((i + 1) % 5) - 2
+        d = ((i + 2) % 5) - 2
+        e = ((i + 3) % 5) - 2
+        db.add(
+            Action(
+                occurred_at=now - timedelta(days=19 - i),
+                domain=domains[i % len(domains)],
+                title=f"Sample action {i + 1}",
+                notes="Seeded demo action",
+                h=h,
+                r=r,
+                d=d,
+                e=e,
+                o_delta=h + r - d + e,
+                tags="demo,seed",
+            )
+        )
+
+    for i in range(12):
+        db.add(
+            Exposure(
+                occurred_at=now - timedelta(days=i * 2),
+                type=exposure_types[i % len(exposure_types)],
+                notes="Seeded demo exposure",
+            )
+        )
+
+    db.commit()
+    return SeedResponse(inserted_actions=20, inserted_exposures=12)

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from datetime import date, datetime
+from typing import Optional
+
+from sqlalchemy import Date, DateTime, Integer, String, Text
+from sqlalchemy.orm import Mapped, mapped_column
+
+from .database import Base
+
+
+class Action(Base):
+    __tablename__ = "actions"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    occurred_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, index=True)
+    domain: Mapped[str] = mapped_column(String(50), default="income", index=True)
+    title: Mapped[str] = mapped_column(String(120))
+    notes: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    h: Mapped[int] = mapped_column(Integer)
+    r: Mapped[int] = mapped_column(Integer)
+    d: Mapped[int] = mapped_column(Integer)
+    e: Mapped[int] = mapped_column(Integer)
+    o_delta: Mapped[int] = mapped_column(Integer, index=True)
+    tags: Mapped[Optional[str]] = mapped_column(String(500), nullable=True)
+
+
+class Exposure(Base):
+    __tablename__ = "exposures"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    occurred_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, index=True)
+    type: Mapped[str] = mapped_column(String(80), index=True)
+    notes: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+
+
+class IncomeModelSettings(Base):
+    __tablename__ = "income_model_settings"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    target_daily_income: Mapped[int] = mapped_column(Integer, default=200)
+    w_s: Mapped[float] = mapped_column(default=0.25)
+    w_n: Mapped[float] = mapped_column(default=0.25)
+    w_l: Mapped[float] = mapped_column(default=0.25)
+    w_e: Mapped[float] = mapped_column(default=0.25)
+    half_life_days: Mapped[int] = mapped_column(Integer, default=21)
+    exposure_goal_per_week: Mapped[int] = mapped_column(Integer, default=5)
+    updated_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+
+
+class IncomeCapitalSnapshot(Base):
+    __tablename__ = "income_capital_snapshot"
+
+    date: Mapped[date] = mapped_column(Date, primary_key=True)
+    s: Mapped[float] = mapped_column(default=0.0)
+    n: Mapped[float] = mapped_column(default=0.0)
+    l: Mapped[float] = mapped_column(default=0.0)
+    e: Mapped[float] = mapped_column(default=0.0)
+    readiness: Mapped[float] = mapped_column(default=0.0)

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+from datetime import date, datetime
+from typing import Literal, Optional
+
+from pydantic import BaseModel, Field
+
+Domain = Literal["income", "sleep", "nutrition", "movement", "stress", "social"]
+
+
+class ActionBase(BaseModel):
+    occurred_at: datetime = Field(default_factory=datetime.utcnow)
+    domain: Domain = "income"
+    title: str = Field(min_length=1, max_length=120)
+    notes: Optional[str] = None
+    h: int = Field(ge=-2, le=2)
+    r: int = Field(ge=-2, le=2)
+    d: int = Field(ge=-2, le=2)
+    e: int = Field(ge=-2, le=2)
+    tags: Optional[str] = None
+
+
+class ActionCreate(ActionBase):
+    pass
+
+
+class ActionUpdate(ActionBase):
+    pass
+
+
+class ActionRead(ActionBase):
+    id: int
+    o_delta: int
+
+    model_config = {"from_attributes": True}
+
+
+class ExposureBase(BaseModel):
+    occurred_at: datetime = Field(default_factory=datetime.utcnow)
+    type: str = Field(min_length=1, max_length=80)
+    notes: Optional[str] = None
+
+
+class ExposureCreate(ExposureBase):
+    pass
+
+
+class ExposureRead(ExposureBase):
+    id: int
+
+    model_config = {"from_attributes": True}
+
+
+class DailyAnalyticsPoint(BaseModel):
+    date: date
+    o_delta_sum: int
+    cumulative: int
+    constraint_debt_7d: int
+    irreversibility_avg: float
+
+
+class WeeklyExposurePoint(BaseModel):
+    week_start: date
+    count: int
+
+
+class CapitalsLatest(BaseModel):
+    s: float = 0.0
+    n: float = 0.0
+    l: float = 0.0
+    e: float = 0.0
+
+
+class AnalyticsTotals(BaseModel):
+    sum_o_delta: int
+    avg_o_delta: float
+    constraint_debt_7d_last: int
+    exposure_count_period: int
+    readiness_latest: float = 0.0
+    capitals_latest: CapitalsLatest = Field(default_factory=CapitalsLatest)
+    confidence_latest: float = 0.0
+
+
+class AnalyticsSummary(BaseModel):
+    totals: AnalyticsTotals
+    daily: list[DailyAnalyticsPoint]
+    weekly_exposure: list[WeeklyExposurePoint]
+
+
+class SeedResponse(BaseModel):
+    inserted_actions: int
+    inserted_exposures: int
+
+
+class IncomeModelSettingsRead(BaseModel):
+    id: int
+    target_daily_income: int
+    w_s: float
+    w_n: float
+    w_l: float
+    w_e: float
+    half_life_days: int
+    exposure_goal_per_week: int
+    updated_at: datetime
+
+    model_config = {"from_attributes": True}
+
+
+class IncomeModelSettingsUpdate(BaseModel):
+    target_daily_income: int = Field(ge=1)
+    w_s: float = Field(ge=0, le=1)
+    w_n: float = Field(ge=0, le=1)
+    w_l: float = Field(ge=0, le=1)
+    w_e: float = Field(ge=0, le=1)
+    half_life_days: int = Field(ge=1)
+    exposure_goal_per_week: int = Field(ge=0)
+
+
+class IncomeModelPoint(BaseModel):
+    date: date
+    s: float
+    n: float
+    l: float
+    e: float
+    readiness: float
+    confidence: float
+    low_data_confidence: bool
+
+
+class IncomeModelSeriesResponse(BaseModel):
+    daily: list[IncomeModelPoint]
+    current: IncomeModelPoint | None
+    settings: IncomeModelSettingsRead
+    explanations: list[str]

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,7 @@
+fastapi==0.115.0
+uvicorn==0.30.6
+sqlalchemy==2.0.35
+pydantic==2.9.2
+pytest==8.3.3
+httpx==0.27.2
+python-dateutil==2.9.0.post0

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/backend/tests/test_analytics.py
+++ b/backend/tests/test_analytics.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from datetime import date, datetime
+
+from app.analytics import compute_summary
+from app.models import Action, Exposure
+
+
+def mk_action(day: str, o_delta: int, r: int) -> Action:
+    occurred = datetime.fromisoformat(f"{day}T12:00:00")
+    return Action(
+        occurred_at=occurred,
+        domain="income",
+        title="x",
+        notes=None,
+        h=0,
+        r=r,
+        d=0,
+        e=0,
+        o_delta=o_delta,
+        tags=None,
+    )
+
+
+def mk_exposure(day: str) -> Exposure:
+    return Exposure(occurred_at=datetime.fromisoformat(f"{day}T09:00:00"), type="post", notes=None)
+
+
+def test_compute_summary_empty():
+    summary = compute_summary([], [], start=date(2024, 1, 1), end=date(2024, 1, 3))
+    assert summary.totals.sum_o_delta == 0
+    assert summary.totals.constraint_debt_7d_last == 0
+    assert len(summary.daily) == 3
+    assert summary.weekly_exposure == []
+
+
+def test_compute_summary_rolling_and_cumulative():
+    actions = [
+        mk_action("2024-01-01", 3, 1),
+        mk_action("2024-01-02", -2, 0),
+        mk_action("2024-01-03", -1, -1),
+        mk_action("2024-01-08", -4, 2),
+    ]
+    exposures = [mk_exposure("2024-01-02"), mk_exposure("2024-01-08")]
+    summary = compute_summary(actions, exposures, start=date(2024, 1, 1), end=date(2024, 1, 8))
+
+    assert summary.daily[0].cumulative == 3
+    assert summary.daily[2].cumulative == 0
+    assert summary.daily[-1].constraint_debt_7d == -7
+    assert summary.totals.sum_o_delta == -4
+    assert summary.totals.exposure_count_period == 2
+
+
+def test_irreversibility_average_per_day():
+    actions = [mk_action("2024-01-01", 0, -2), mk_action("2024-01-01", 0, 2)]
+    summary = compute_summary(actions, [], start=date(2024, 1, 1), end=date(2024, 1, 1))
+    assert summary.daily[0].irreversibility_avg == 2.0

--- a/backend/tests/test_income_model.py
+++ b/backend/tests/test_income_model.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from datetime import date, datetime
+
+from fastapi.testclient import TestClient
+
+from app.income_model import clamp01, compute_income_series, decay_factor, saturate
+from app.main import app
+from app.models import Action, Exposure, IncomeModelSettings
+
+
+def test_decay_factor_half_life():
+    assert decay_factor(0, 21) == 1.0
+    assert round(decay_factor(21, 21), 6) == 0.5
+
+
+def test_saturation_monotonic_bounded():
+    a = saturate(0.1, 0.7)
+    b = saturate(1.0, 0.7)
+    c = saturate(4.0, 0.7)
+    assert 0 <= a <= 1
+    assert 0 <= b <= 1
+    assert 0 <= c <= 1
+    assert a < b < c
+
+
+def test_low_data_defaults_and_confidence():
+    settings = IncomeModelSettings(
+        id=1,
+        target_daily_income=200,
+        w_s=0.25,
+        w_n=0.25,
+        w_l=0.25,
+        w_e=0.25,
+        half_life_days=21,
+        exposure_goal_per_week=5,
+        updated_at=datetime.utcnow(),
+    )
+    points = compute_income_series([], [], date(2024, 1, 1), date(2024, 1, 2), settings)
+    assert points[-1].low_data_confidence is True
+    assert points[-1].confidence == 0.0
+    assert 0 <= points[-1].readiness <= 100
+
+
+def test_weight_sum_validation_endpoint():
+    client = TestClient(app)
+    res = client.put(
+        "/api/income-model/settings",
+        json={
+            "target_daily_income": 200,
+            "w_s": 0.4,
+            "w_n": 0.4,
+            "w_l": 0.4,
+            "w_e": 0.1,
+            "half_life_days": 21,
+            "exposure_goal_per_week": 5,
+        },
+    )
+    assert res.status_code == 400
+
+
+
+def test_clamp01():
+    assert clamp01(-1) == 0
+    assert clamp01(0.3) == 0.3
+    assert clamp01(9) == 1

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Optionality Tracker</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,0 +1,2150 @@
+{
+  "name": "optionality-tracker-frontend",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "optionality-tracker-frontend",
+      "version": "0.1.0",
+      "dependencies": {
+        "react": "^18.3.1",
+        "react-dom": "^18.3.1",
+        "react-router-dom": "^6.27.0",
+        "recharts": "^2.12.7"
+      },
+      "devDependencies": {
+        "@types/lodash": "^4.17.24",
+        "@types/react": "^18.3.11",
+        "@types/react-dom": "^18.3.0",
+        "@vitejs/plugin-react": "^4.3.1",
+        "typescript": "^5.6.2",
+        "vite": "^5.4.8"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
+      "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
+      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-compilation-targets": "^7.28.6",
+        "@babel/helper-module-transforms": "^7.28.6",
+        "@babel/helpers": "^7.28.6",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/traverse": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.1",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
+      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
+      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.28.6",
+        "@babel/helper-validator-option": "^7.27.1",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
+      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
+      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
+      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.28.6",
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/traverse": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz",
+      "integrity": "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
+      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.6.tgz",
+      "integrity": "sha512-xOBvwq86HHdB7WUDTfKfT/Vuxh7gElQ+Sfti2Cy6yIWNW05P8iUslOVcZ4/sKbE+/jQaukQAdz/gf3724kYdqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.0.tgz",
+      "integrity": "sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-self": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.27.1.tgz",
+      "integrity": "sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-source": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.27.1.tgz",
+      "integrity": "sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
+      "integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
+      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.28.6",
+        "@babel/parser": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
+      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-globals": "^7.28.0",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@remix-run/router": {
+      "version": "1.23.2",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.2.tgz",
+      "integrity": "sha512-Ic6m2U/rMjTkhERIa/0ZtXJP17QUi2CbWE7cqx4J58M8aA3QTfW+2UlQ4psvTX9IO1RfNVhK3pcpdjej7L+t2w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-beta.27",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
+      "integrity": "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.59.0.tgz",
+      "integrity": "sha512-upnNBkA6ZH2VKGcBj9Fyl9IGNPULcjXRlg0LLeaioQWueH30p6IXtJEbKAgvyv+mJaMxSm1l6xwDXYjpEMiLMg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.59.0.tgz",
+      "integrity": "sha512-hZ+Zxj3SySm4A/DylsDKZAeVg0mvi++0PYVceVyX7hemkw7OreKdCvW2oQ3T1FMZvCaQXqOTHb8qmBShoqk69Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.59.0.tgz",
+      "integrity": "sha512-W2Psnbh1J8ZJw0xKAd8zdNgF9HRLkdWwwdWqubSVk0pUuQkoHnv7rx4GiF9rT4t5DIZGAsConRE3AxCdJ4m8rg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.59.0.tgz",
+      "integrity": "sha512-ZW2KkwlS4lwTv7ZVsYDiARfFCnSGhzYPdiOU4IM2fDbL+QGlyAbjgSFuqNRbSthybLbIJ915UtZBtmuLrQAT/w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.59.0.tgz",
+      "integrity": "sha512-EsKaJ5ytAu9jI3lonzn3BgG8iRBjV4LxZexygcQbpiU0wU0ATxhNVEpXKfUa0pS05gTcSDMKpn3Sx+QB9RlTTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.59.0.tgz",
+      "integrity": "sha512-d3DuZi2KzTMjImrxoHIAODUZYoUUMsuUiY4SRRcJy6NJoZ6iIqWnJu9IScV9jXysyGMVuW+KNzZvBLOcpdl3Vg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.59.0.tgz",
+      "integrity": "sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.59.0.tgz",
+      "integrity": "sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.59.0.tgz",
+      "integrity": "sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.59.0.tgz",
+      "integrity": "sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.59.0.tgz",
+      "integrity": "sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.59.0.tgz",
+      "integrity": "sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.59.0.tgz",
+      "integrity": "sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.59.0.tgz",
+      "integrity": "sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.59.0.tgz",
+      "integrity": "sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.59.0.tgz",
+      "integrity": "sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.59.0.tgz",
+      "integrity": "sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.59.0.tgz",
+      "integrity": "sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.59.0.tgz",
+      "integrity": "sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.59.0.tgz",
+      "integrity": "sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.59.0.tgz",
+      "integrity": "sha512-tt9KBJqaqp5i5HUZzoafHZX8b5Q2Fe7UjYERADll83O4fGqJ49O1FsL6LpdzVFQcpwvnyd0i+K/VSwu/o/nWlA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.59.0.tgz",
+      "integrity": "sha512-V5B6mG7OrGTwnxaNUzZTDTjDS7F75PO1ae6MJYdiMu60sq0CqN5CVeVsbhPxalupvTX8gXVSU9gq+Rx1/hvu6A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.59.0.tgz",
+      "integrity": "sha512-UKFMHPuM9R0iBegwzKF4y0C4J9u8C6MEJgFuXTBerMk7EJ92GFVFYBfOZaSGLu6COf7FxpQNqhNS4c4icUPqxA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.59.0.tgz",
+      "integrity": "sha512-laBkYlSS1n2L8fSo1thDNGrCTQMmxjYY5G0WFWjFFYZkKPjsMBsgJfGf4TLxXrF6RyhI60L8TMOjBMvXiTcxeA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.59.0.tgz",
+      "integrity": "sha512-2HRCml6OztYXyJXAvdDXPKcawukWY2GpR5/nxKp4iBgiO3wcoEGkAaqctIbZcNB6KlUQBIqt8VYkNSj2397EfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/babel__core": {
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "node_modules/@types/babel__generator": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__traverse": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.2"
+      }
+    },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/lodash": {
+      "version": "4.17.24",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.24.tgz",
+      "integrity": "sha512-gIW7lQLZbue7lRSWEFql49QJJWThrTFFeIMJdp3eH4tKoxm1OvEPg02rm4wCCSHS0cL3/Fizimb35b7k8atwsQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/prop-types": {
+      "version": "15.7.15",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/react": {
+      "version": "18.3.28",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
+      "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "18.3.7",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
+      "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^18.0.0"
+      }
+    },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
+      "integrity": "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.28.0",
+        "@babel/plugin-transform-react-jsx-self": "^7.27.1",
+        "@babel/plugin-transform-react-jsx-source": "^7.27.1",
+        "@rolldown/pluginutils": "1.0.0-beta.27",
+        "@types/babel__core": "^7.20.5",
+        "react-refresh": "^0.17.0"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+      }
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.0.tgz",
+      "integrity": "sha512-lIyg0szRfYbiy67j9KN8IyeD7q7hcmqnJ1ddWmNt19ItGpNN64mnllmxUNFIOdOm6by97jlL6wfpTTJrmnjWAA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
+      "integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.9.0",
+        "caniuse-lite": "^1.0.30001759",
+        "electron-to-chromium": "^1.5.263",
+        "node-releases": "^2.0.27",
+        "update-browserslist-db": "^1.2.0"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001774",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001774.tgz",
+      "integrity": "sha512-DDdwPGz99nmIEv216hKSgLD+D4ikHQHjBC/seF98N9CPqRX4M5mSxT9eTV6oyisnJcuzxtZy4n17yKKQYmYQOA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "license": "MIT"
+    },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
+      "license": "MIT"
+    },
+    "node_modules/dom-helpers": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
+      "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.8.7",
+        "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.302",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.302.tgz",
+      "integrity": "sha512-sM6HAN2LyK82IyPBpznDRqlTQAtuSaO+ShzFiWTvoMJLHyZ+Y39r8VMfHzwbU8MVBzQ4Wdn85+wlZl2TLGIlwg==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+      "license": "MIT"
+    },
+    "node_modules/fast-equals": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-5.4.0.tgz",
+      "integrity": "sha512-jt2DW/aNFNwke7AUd+Z+e6pz39KO5rzdbbFCg2sGafS4mk13MI7Z8O5z9cADNn5lhGODIgLwug6TZO2ctf7kcw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "license": "MIT"
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
+      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "license": "MIT"
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.27",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
+      "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/postcss": {
+      "version": "8.5.6",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
+      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
+    "node_modules/prop-types/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
+    },
+    "node_modules/react": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.2"
+      },
+      "peerDependencies": {
+        "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "license": "MIT"
+    },
+    "node_modules/react-refresh": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
+      "integrity": "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-router": {
+      "version": "6.30.3",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.3.tgz",
+      "integrity": "sha512-XRnlbKMTmktBkjCLE8/XcZFlnHvr2Ltdr1eJX4idL55/9BbORzyZEaIkBFDhFGCEWBBItsVrDxwx3gnisMitdw==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.23.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "6.30.3",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.3.tgz",
+      "integrity": "sha512-pxPcv1AczD4vso7G4Z3TKcvlxK7g7TNt3/FNGMhfqyntocvYKj+GCatfigGDjbLozC4baguJ0ReCigoDJXb0ag==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.23.2",
+        "react-router": "6.30.3"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/react-smooth": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/react-smooth/-/react-smooth-4.0.4.tgz",
+      "integrity": "sha512-gnGKTpYwqL0Iii09gHobNolvX4Kiq4PKx6eWBCYYix+8cdw+cGo3do906l1NBPKkSWx1DghC1dlWG9L2uGd61Q==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-equals": "^5.0.1",
+        "prop-types": "^15.8.1",
+        "react-transition-group": "^4.4.5"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/react-transition-group": {
+      "version": "4.4.5",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
+      "integrity": "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@babel/runtime": "^7.5.5",
+        "dom-helpers": "^5.0.1",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.6.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0",
+        "react-dom": ">=16.6.0"
+      }
+    },
+    "node_modules/recharts": {
+      "version": "2.15.4",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-2.15.4.tgz",
+      "integrity": "sha512-UT/q6fwS3c1dHbXv2uFgYJ9BMFHu3fwnd7AYZaEQhXuYQ4hgsxLvsUXzGdKeZrW5xopzDCvuA2N41WJ88I7zIw==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^2.0.0",
+        "eventemitter3": "^4.0.1",
+        "lodash": "^4.17.21",
+        "react-is": "^18.3.1",
+        "react-smooth": "^4.0.4",
+        "recharts-scale": "^0.4.4",
+        "tiny-invariant": "^1.3.1",
+        "victory-vendor": "^36.6.8"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "react": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/recharts-scale": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/recharts-scale/-/recharts-scale-0.4.5.tgz",
+      "integrity": "sha512-kivNFO+0OcUNu7jQquLXAxz1FIwZj8nrj+YkOKc5694NbjCvcT6aSZiIzNzd2Kul4o4rTto8QVR9lMNtxD4G1w==",
+      "license": "MIT",
+      "dependencies": {
+        "decimal.js-light": "^2.4.1"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.59.0.tgz",
+      "integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.59.0",
+        "@rollup/rollup-android-arm64": "4.59.0",
+        "@rollup/rollup-darwin-arm64": "4.59.0",
+        "@rollup/rollup-darwin-x64": "4.59.0",
+        "@rollup/rollup-freebsd-arm64": "4.59.0",
+        "@rollup/rollup-freebsd-x64": "4.59.0",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.59.0",
+        "@rollup/rollup-linux-arm-musleabihf": "4.59.0",
+        "@rollup/rollup-linux-arm64-gnu": "4.59.0",
+        "@rollup/rollup-linux-arm64-musl": "4.59.0",
+        "@rollup/rollup-linux-loong64-gnu": "4.59.0",
+        "@rollup/rollup-linux-loong64-musl": "4.59.0",
+        "@rollup/rollup-linux-ppc64-gnu": "4.59.0",
+        "@rollup/rollup-linux-ppc64-musl": "4.59.0",
+        "@rollup/rollup-linux-riscv64-gnu": "4.59.0",
+        "@rollup/rollup-linux-riscv64-musl": "4.59.0",
+        "@rollup/rollup-linux-s390x-gnu": "4.59.0",
+        "@rollup/rollup-linux-x64-gnu": "4.59.0",
+        "@rollup/rollup-linux-x64-musl": "4.59.0",
+        "@rollup/rollup-openbsd-x64": "4.59.0",
+        "@rollup/rollup-openharmony-arm64": "4.59.0",
+        "@rollup/rollup-win32-arm64-msvc": "4.59.0",
+        "@rollup/rollup-win32-ia32-msvc": "4.59.0",
+        "@rollup/rollup-win32-x64-gnu": "4.59.0",
+        "@rollup/rollup-win32-x64-msvc": "4.59.0",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
+    },
+    "node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/victory-vendor": {
+      "version": "36.9.2",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-36.9.2.tgz",
+      "integrity": "sha512-PnpQQMuxlwYdocC8fIJqVXvkeViHYzotI+NJrCuav0ZYFoq912ZHBk3mCeuj+5/VpodOjPe1z0Fk2ihgzlXqjQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
+      }
+    },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "license": "ISC"
+    }
+  }
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "optionality-tracker-frontend",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc -b && vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "react-router-dom": "^6.27.0",
+    "recharts": "^2.12.7"
+  },
+  "devDependencies": {
+    "@types/lodash": "^4.17.24",
+    "@types/react": "^18.3.11",
+    "@types/react-dom": "^18.3.0",
+    "@vitejs/plugin-react": "^4.3.1",
+    "typescript": "^5.6.2",
+    "vite": "^5.4.8"
+  }
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,0 +1,30 @@
+import { Link, Navigate, Route, Routes } from 'react-router-dom';
+import DashboardPage from './pages/DashboardPage';
+import IncomeModelPage from './pages/IncomeModelPage';
+import LogActionPage from './pages/LogActionPage';
+import LogExposurePage from './pages/LogExposurePage';
+
+export default function App() {
+  return (
+    <div className="app-shell">
+      <header>
+        <h1>Optionality Tracker</h1>
+        <nav>
+          <Link to="/dashboard">Dashboard</Link>
+          <Link to="/income-model">Income Model</Link>
+          <Link to="/log-action">Log Action</Link>
+          <Link to="/log-exposure">Log Exposure</Link>
+        </nav>
+      </header>
+      <main>
+        <Routes>
+          <Route path="/" element={<Navigate to="/dashboard" replace />} />
+          <Route path="/dashboard" element={<DashboardPage />} />
+          <Route path="/income-model" element={<IncomeModelPage />} />
+          <Route path="/log-action" element={<LogActionPage />} />
+          <Route path="/log-exposure" element={<LogExposurePage />} />
+        </Routes>
+      </main>
+    </div>
+  );
+}

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1,0 +1,72 @@
+import type { AnalyticsSummary, Domain, IncomeModelSeries, IncomeModelSettings } from './types';
+
+const API_BASE = 'http://localhost:8000';
+
+export interface ActionPayload {
+  occurred_at: string;
+  domain: Domain;
+  title: string;
+  notes?: string;
+  h: number;
+  r: number;
+  d: number;
+  e: number;
+  tags?: string;
+}
+
+export interface ExposurePayload {
+  occurred_at: string;
+  type: string;
+  notes?: string;
+}
+
+export async function getAnalytics(start: string, end: string): Promise<AnalyticsSummary> {
+  const res = await fetch(`${API_BASE}/api/analytics/summary?start=${start}&end=${end}`);
+  if (!res.ok) throw new Error('Failed to load analytics');
+  return res.json();
+}
+
+export async function createAction(payload: ActionPayload): Promise<void> {
+  const res = await fetch(`${API_BASE}/api/actions`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  });
+  if (!res.ok) throw new Error('Failed to create action');
+}
+
+export async function createExposure(payload: ExposurePayload): Promise<void> {
+  const res = await fetch(`${API_BASE}/api/exposures`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  });
+  if (!res.ok) throw new Error('Failed to create exposure');
+}
+
+export async function getIncomeSettings(): Promise<IncomeModelSettings> {
+  const res = await fetch(`${API_BASE}/api/income-model/settings`);
+  if (!res.ok) throw new Error('Failed to load settings');
+  return res.json();
+}
+
+export async function updateIncomeSettings(payload: Omit<IncomeModelSettings, 'id' | 'updated_at'>): Promise<IncomeModelSettings> {
+  const res = await fetch(`${API_BASE}/api/income-model/settings`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  });
+  if (!res.ok) throw new Error('Failed to update settings');
+  return res.json();
+}
+
+export async function getIncomeSeries(start: string, end: string): Promise<IncomeModelSeries> {
+  const res = await fetch(`${API_BASE}/api/income-model/series?start=${start}&end=${end}`);
+  if (!res.ok) throw new Error('Failed to load income series');
+  return res.json();
+}
+
+export async function seedData(): Promise<void> {
+  const res = await fetch(`${API_BASE}/api/dev/seed`, { method: 'POST' });
+  if (!res.ok) throw new Error('Failed to seed data');
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { BrowserRouter } from 'react-router-dom';
+import App from './App';
+import './styles.css';
+
+ReactDOM.createRoot(document.getElementById('root')!).render(
+  <React.StrictMode>
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
+  </React.StrictMode>,
+);

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -1,0 +1,120 @@
+import { ReactNode, useEffect, useState } from 'react';
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  Line,
+  LineChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts';
+import { getAnalytics, getIncomeSeries, seedData } from '../api';
+import type { AnalyticsSummary, IncomeModelSeries } from '../types';
+
+function formatDateInput(d: Date): string {
+  return d.toISOString().slice(0, 10);
+}
+
+export default function DashboardPage() {
+  const today = new Date();
+  const startDefault = new Date(today);
+  startDefault.setDate(today.getDate() - 29);
+
+  const [start, setStart] = useState<string>(formatDateInput(startDefault));
+  const [end, setEnd] = useState<string>(formatDateInput(today));
+  const [data, setData] = useState<AnalyticsSummary | null>(null);
+  const [income, setIncome] = useState<IncomeModelSeries | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  async function refresh() {
+    setLoading(true);
+    try {
+      const [analytics, incomeSeries] = await Promise.all([getAnalytics(start, end), getIncomeSeries(start, end)]);
+      setData(analytics);
+      setIncome(incomeSeries);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    refresh();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return (
+    <section>
+      <div className="row">
+        <label>Start</label>
+        <input type="date" value={start} onChange={(e) => setStart(e.target.value)} />
+        <label>End</label>
+        <input type="date" value={end} onChange={(e) => setEnd(e.target.value)} />
+        <button onClick={refresh}>Refresh</button>
+        <button
+          onClick={async () => {
+            await seedData();
+            await refresh();
+          }}
+        >
+          Seed Demo Data
+        </button>
+      </div>
+
+      {loading && <p>Loading…</p>}
+      {data && (
+        <>
+          <div className="kpi-grid">
+            <article className="card"><h3>Cumulative Optionality</h3><p>{data.totals.sum_o_delta}</p></article>
+            <article className="card"><h3>Avg O_delta/day</h3><p>{data.totals.avg_o_delta}</p></article>
+            <article className="card"><h3>Latest Constraint Debt (7d)</h3><p>{data.totals.constraint_debt_7d_last}</p></article>
+            <article className="card"><h3>Exposures (period)</h3><p>{data.totals.exposure_count_period}</p></article>
+            <article className="card"><h3>Target Readiness</h3><p>{data.totals.readiness_latest}%</p><small>confidence {Math.round(data.totals.confidence_latest * 100)}%</small></article>
+          </div>
+
+          <div className="card">
+            <h3>Capital breakdown</h3>
+            <p>S: {data.totals.capitals_latest.s.toFixed(2)} · N: {data.totals.capitals_latest.n.toFixed(2)} · L: {data.totals.capitals_latest.l.toFixed(2)} · E: {data.totals.capitals_latest.e.toFixed(2)}</p>
+            <p>
+              {data.totals.capitals_latest.l < 0.4
+                ? 'Lead capital is low → aim to log exposures toward your weekly goal.'
+                : 'Lead capital is in a healthy range.'}
+            </p>
+          </div>
+
+          <div className="chart-grid">
+            <ChartCard title="Cumulative Optionality">
+              <ResponsiveContainer width="100%" height={240}><LineChart data={data.daily}><CartesianGrid strokeDasharray="3 3" /><XAxis dataKey="date" /><YAxis /><Tooltip /><Line type="monotone" dataKey="cumulative" stroke="#3b82f6" dot={false} /></LineChart></ResponsiveContainer>
+            </ChartCard>
+
+            <ChartCard title="Constraint Debt (7d Rolling)">
+              <ResponsiveContainer width="100%" height={240}><LineChart data={data.daily}><CartesianGrid strokeDasharray="3 3" /><XAxis dataKey="date" /><YAxis /><Tooltip /><Line type="monotone" dataKey="constraint_debt_7d" stroke="#ef4444" dot={false} /></LineChart></ResponsiveContainer>
+            </ChartCard>
+
+            <ChartCard title="Irreversibility Proxy">
+              <ResponsiveContainer width="100%" height={240}><LineChart data={data.daily}><CartesianGrid strokeDasharray="3 3" /><XAxis dataKey="date" /><YAxis domain={[0, 4]} /><Tooltip /><Line type="monotone" dataKey="irreversibility_avg" stroke="#8b5cf6" dot={false} /></LineChart></ResponsiveContainer>
+            </ChartCard>
+
+            <ChartCard title="Exposures per Week">
+              <ResponsiveContainer width="100%" height={240}><BarChart data={data.weekly_exposure}><CartesianGrid strokeDasharray="3 3" /><XAxis dataKey="week_start" /><YAxis /><Tooltip /><Bar dataKey="count" fill="#10b981" /></BarChart></ResponsiveContainer>
+            </ChartCard>
+
+            <ChartCard title="Target Readiness Trend">
+              <ResponsiveContainer width="100%" height={240}><LineChart data={income?.daily ?? []}><CartesianGrid strokeDasharray="3 3" /><XAxis dataKey="date" /><YAxis domain={[0, 100]} /><Tooltip /><Line type="monotone" dataKey="readiness" stroke="#f59e0b" dot={false} /></LineChart></ResponsiveContainer>
+            </ChartCard>
+          </div>
+        </>
+      )}
+    </section>
+  );
+}
+
+function ChartCard({ title, children }: { title: string; children: ReactNode }) {
+  return (
+    <article className="card">
+      <h3>{title}</h3>
+      {children}
+    </article>
+  );
+}

--- a/frontend/src/pages/IncomeModelPage.tsx
+++ b/frontend/src/pages/IncomeModelPage.tsx
@@ -1,0 +1,88 @@
+import { FormEvent, useEffect, useMemo, useState } from 'react';
+import { getIncomeSeries, getIncomeSettings, updateIncomeSettings } from '../api';
+import type { IncomeModelSeries, IncomeModelSettings } from '../types';
+
+export default function IncomeModelPage() {
+  const [settings, setSettings] = useState<IncomeModelSettings | null>(null);
+  const [series, setSeries] = useState<IncomeModelSeries | null>(null);
+
+  useEffect(() => {
+    (async () => {
+      const s = await getIncomeSettings();
+      setSettings(s);
+      const today = new Date();
+      const start = new Date();
+      start.setDate(today.getDate() - 29);
+      setSeries(await getIncomeSeries(start.toISOString().slice(0, 10), today.toISOString().slice(0, 10)));
+    })();
+  }, []);
+
+  const preview = useMemo(() => {
+    if (!settings || !series?.current) return null;
+    const c = series.current;
+    return 100 * (settings.w_s * c.s + settings.w_n * c.n + settings.w_l * c.l + settings.w_e * c.e);
+  }, [settings, series]);
+
+  function rebalance(which: 'w_s' | 'w_n' | 'w_l' | 'w_e', value: number) {
+    if (!settings) return;
+    const rest = ['w_s', 'w_n', 'w_l', 'w_e'].filter((k) => k !== which) as Array<'w_s' | 'w_n' | 'w_l' | 'w_e'>;
+    const remaining = Math.max(0, 1 - value);
+    const currentRest = rest.reduce((sum, k) => sum + settings[k], 0) || 1;
+    const next = { ...settings, [which]: value };
+    rest.forEach((k) => {
+      next[k] = (settings[k] / currentRest) * remaining;
+    });
+    setSettings(next);
+  }
+
+  async function onSave(e: FormEvent) {
+    e.preventDefault();
+    if (!settings) return;
+    const payload = {
+      target_daily_income: settings.target_daily_income,
+      w_s: settings.w_s,
+      w_n: settings.w_n,
+      w_l: settings.w_l,
+      w_e: settings.w_e,
+      half_life_days: settings.half_life_days,
+      exposure_goal_per_week: settings.exposure_goal_per_week,
+    };
+    const updated = await updateIncomeSettings(payload);
+    setSettings(updated);
+  }
+
+  if (!settings) return <p>Loading…</p>;
+
+  return (
+    <section className="card form-card">
+      <h2>Income Model</h2>
+      <form className="form-grid" onSubmit={onSave}>
+        <label>Target daily income</label>
+        <input type="number" value={settings.target_daily_income} onChange={(e) => setSettings({ ...settings, target_daily_income: Number(e.target.value) })} />
+
+        <label>Skill weight ({settings.w_s.toFixed(2)})</label>
+        <input type="range" min={0} max={1} step={0.01} value={settings.w_s} onChange={(e) => rebalance('w_s', Number(e.target.value))} />
+
+        <label>Network weight ({settings.w_n.toFixed(2)})</label>
+        <input type="range" min={0} max={1} step={0.01} value={settings.w_n} onChange={(e) => rebalance('w_n', Number(e.target.value))} />
+
+        <label>Lead weight ({settings.w_l.toFixed(2)})</label>
+        <input type="range" min={0} max={1} step={0.01} value={settings.w_l} onChange={(e) => rebalance('w_l', Number(e.target.value))} />
+
+        <label>Energy weight ({settings.w_e.toFixed(2)})</label>
+        <input type="range" min={0} max={1} step={0.01} value={settings.w_e} onChange={(e) => rebalance('w_e', Number(e.target.value))} />
+
+        <label>Half-life days</label>
+        <input type="number" value={settings.half_life_days} onChange={(e) => setSettings({ ...settings, half_life_days: Number(e.target.value) })} />
+
+        <label>Exposure goal/week</label>
+        <input type="number" value={settings.exposure_goal_per_week} onChange={(e) => setSettings({ ...settings, exposure_goal_per_week: Number(e.target.value) })} />
+
+        <p>Live preview readiness: {preview?.toFixed(1) ?? '--'}%</p>
+        <p>Capitals: Skill (S), Network (N), Lead (L), Energy (E). Transparent heuristic from logs.</p>
+
+        <button type="submit">Save Model Settings</button>
+      </form>
+    </section>
+  );
+}

--- a/frontend/src/pages/LogActionPage.tsx
+++ b/frontend/src/pages/LogActionPage.tsx
@@ -1,0 +1,82 @@
+import { FormEvent, useMemo, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { createAction } from '../api';
+import type { Domain } from '../types';
+
+const domains: Domain[] = ['income', 'sleep', 'nutrition', 'movement', 'stress', 'social'];
+const scoreValues = [-2, -1, 0, 1, 2];
+
+export default function LogActionPage() {
+  const navigate = useNavigate();
+  const [title, setTitle] = useState('');
+  const [occurredAt, setOccurredAt] = useState(new Date().toISOString().slice(0, 16));
+  const [notes, setNotes] = useState('');
+  const [domain, setDomain] = useState<Domain>('income');
+  const [h, setH] = useState(0);
+  const [r, setR] = useState(0);
+  const [d, setD] = useState(0);
+  const [e, setE] = useState(0);
+  const [tags, setTags] = useState('');
+
+  const oDelta = useMemo(() => h + r - d + e, [h, r, d, e]);
+
+  async function onSubmit(event: FormEvent) {
+    event.preventDefault();
+    await createAction({
+      title,
+      occurred_at: new Date(occurredAt).toISOString(),
+      notes,
+      domain,
+      h,
+      r,
+      d,
+      e,
+      tags,
+    });
+    navigate('/dashboard');
+  }
+
+  return (
+    <section className="card form-card">
+      <h2>Log Action</h2>
+      <form onSubmit={onSubmit} className="form-grid">
+        <label>Title</label>
+        <input value={title} onChange={(e) => setTitle(e.target.value)} required />
+
+        <label>Occurred At</label>
+        <input type="datetime-local" value={occurredAt} onChange={(e) => setOccurredAt(e.target.value)} required />
+
+        <label>Domain</label>
+        <select value={domain} onChange={(e) => setDomain(e.target.value as Domain)}>
+          {domains.map((dItem) => (
+            <option key={dItem} value={dItem}>
+              {dItem}
+            </option>
+          ))}
+        </select>
+
+        <label>H Score</label>
+        <select value={h} onChange={(e) => setH(Number(e.target.value))}>{scoreValues.map((v) => <option key={`h-${v}`} value={v}>{v}</option>)}</select>
+
+        <label>R Score</label>
+        <select value={r} onChange={(e) => setR(Number(e.target.value))}>{scoreValues.map((v) => <option key={`r-${v}`} value={v}>{v}</option>)}</select>
+
+        <label>D Score</label>
+        <select value={d} onChange={(e) => setD(Number(e.target.value))}>{scoreValues.map((v) => <option key={`d-${v}`} value={v}>{v}</option>)}</select>
+
+        <label>E Score</label>
+        <select value={e} onChange={(e) => setE(Number(e.target.value))}>{scoreValues.map((v) => <option key={`e-${v}`} value={v}>{v}</option>)}</select>
+
+        <label>Tags</label>
+        <input value={tags} onChange={(e) => setTags(e.target.value)} placeholder="comma,separated" />
+
+        <label>Notes</label>
+        <textarea value={notes} onChange={(e) => setNotes(e.target.value)} rows={4} />
+
+        <p className="o-delta">Computed O_delta: {oDelta}</p>
+
+        <button type="submit">Save Action</button>
+      </form>
+    </section>
+  );
+}

--- a/frontend/src/pages/LogExposurePage.tsx
+++ b/frontend/src/pages/LogExposurePage.tsx
@@ -1,0 +1,46 @@
+import { FormEvent, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { createExposure } from '../api';
+
+const exposureTypes = ['application', 'outreach', 'post', 'proposal', 'interview', 'portfolio_update'];
+
+export default function LogExposurePage() {
+  const navigate = useNavigate();
+  const [type, setType] = useState(exposureTypes[0]);
+  const [occurredAt, setOccurredAt] = useState(new Date().toISOString().slice(0, 16));
+  const [notes, setNotes] = useState('');
+
+  async function onSubmit(event: FormEvent) {
+    event.preventDefault();
+    await createExposure({
+      type,
+      occurred_at: new Date(occurredAt).toISOString(),
+      notes,
+    });
+    navigate('/dashboard');
+  }
+
+  return (
+    <section className="card form-card">
+      <h2>Log Exposure</h2>
+      <form onSubmit={onSubmit} className="form-grid">
+        <label>Type</label>
+        <select value={type} onChange={(e) => setType(e.target.value)}>
+          {exposureTypes.map((item) => (
+            <option key={item} value={item}>
+              {item}
+            </option>
+          ))}
+        </select>
+
+        <label>Occurred At</label>
+        <input type="datetime-local" value={occurredAt} onChange={(e) => setOccurredAt(e.target.value)} required />
+
+        <label>Notes</label>
+        <textarea value={notes} onChange={(e) => setNotes(e.target.value)} rows={4} />
+
+        <button type="submit">Save Exposure</button>
+      </form>
+    </section>
+  );
+}

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1,0 +1,83 @@
+:root {
+  font-family: Inter, system-ui, Arial, sans-serif;
+  color: #0f172a;
+  background: #f8fafc;
+}
+
+body {
+  margin: 0;
+}
+
+.app-shell {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 1rem;
+}
+
+header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+}
+
+nav {
+  display: flex;
+  gap: 1rem;
+}
+
+nav a {
+  text-decoration: none;
+}
+
+.row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+  flex-wrap: wrap;
+}
+
+.kpi-grid,
+.chart-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 1rem;
+}
+
+.card {
+  background: white;
+  border-radius: 12px;
+  padding: 1rem;
+  box-shadow: 0 1px 8px rgba(15, 23, 42, 0.08);
+}
+
+.form-card {
+  max-width: 640px;
+}
+
+.form-grid {
+  display: grid;
+  gap: 0.5rem;
+}
+
+input,
+select,
+textarea,
+button {
+  padding: 0.55rem;
+  border-radius: 8px;
+  border: 1px solid #cbd5e1;
+  font: inherit;
+}
+
+button {
+  cursor: pointer;
+  background: #2563eb;
+  color: white;
+  border: none;
+}
+
+.o-delta {
+  font-weight: 600;
+}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1,0 +1,58 @@
+export type Domain = 'income' | 'sleep' | 'nutrition' | 'movement' | 'stress' | 'social';
+
+export interface DailyPoint {
+  date: string;
+  o_delta_sum: number;
+  cumulative: number;
+  constraint_debt_7d: number;
+  irreversibility_avg: number;
+}
+
+export interface WeeklyExposurePoint {
+  week_start: string;
+  count: number;
+}
+
+export interface AnalyticsSummary {
+  totals: {
+    sum_o_delta: number;
+    avg_o_delta: number;
+    constraint_debt_7d_last: number;
+    exposure_count_period: number;
+    readiness_latest: number;
+    capitals_latest: { s: number; n: number; l: number; e: number };
+    confidence_latest: number;
+  };
+  daily: DailyPoint[];
+  weekly_exposure: WeeklyExposurePoint[];
+}
+
+export interface IncomeModelSettings {
+  id: number;
+  target_daily_income: number;
+  w_s: number;
+  w_n: number;
+  w_l: number;
+  w_e: number;
+  half_life_days: number;
+  exposure_goal_per_week: number;
+  updated_at: string;
+}
+
+export interface IncomeModelPoint {
+  date: string;
+  s: number;
+  n: number;
+  l: number;
+  e: number;
+  readiness: number;
+  confidence: number;
+  low_data_confidence: boolean;
+}
+
+export interface IncomeModelSeries {
+  daily: IncomeModelPoint[];
+  current: IncomeModelPoint | null;
+  settings: IncomeModelSettings;
+  explanations: string[];
+}

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "jsx": "react-jsx",
+    "strict": true,
+    "moduleResolution": "Bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "types": ["vite/client"]
+  },
+  "include": ["src"]
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5173,
+  },
+});


### PR DESCRIPTION
### Motivation
- Replace the previous demo content with a focused "Optionality Tracker" implementing an income-target readiness model and analytics to track actions and exposures. 
- Provide a REST API and a simple React + TypeScript dashboard to visualize readiness, capital breakdown (S/N/L/E), and analytics trends. 
- Persist model settings and logs in SQLite for deterministic computation and to enable frontend editing and live previews. 

### Description
- Added a FastAPI backend under `backend/app` with DB wiring (`database.py`), ORM models (`models.py`), Pydantic schemas (`schemas.py`), analytics computation (`analytics.py`), income target/readiness model (`income_model.py`), and API endpoints (`main.py`) including `GET/PUT /api/income-model/settings`, `GET /api/income-model/series`, `POST/GET/PUT/DELETE /api/actions`, `POST/GET/DELETE /api/exposures`, `GET /api/analytics/summary`, and `POST /api/dev/seed` for demo data. 
- Implemented an income model that decays signals with configurable `half_life_days`, saturates capitals, applies a variance penalty for energy stability, and computes `readiness` and `confidence`; included `get_or_create_settings` and `compute_income_series`. 
- Added a lightweight React + TypeScript frontend in `frontend/src` with pages for Dashboard, Income Model editing, Log Action, and Log Exposure, an API client (`api.ts`), type definitions (`types.ts`), basic styling (`styles.css`), and Vite config and package manifests. 
- Project scaffolding and docs: updated `README.md` with run instructions, added `backend/requirements.txt`, a `.gitignore` tuned for Python/Node artifacts, and committed `package-lock.json` for the frontend. 

### Testing
- Added unit tests under `backend/tests`: `test_analytics.py` and `test_income_model.py` covering summary aggregation, decay/saturation helpers, low-data defaults, and API weight-sum validation. 
- Ran the backend test suite with `cd backend && pytest -q`; the test files `backend/tests/test_analytics.py` and `backend/tests/test_income_model.py` executed and passed. 
- Manual seed endpoint is available via `POST /api/dev/seed` to populate demo data used by the tests and frontend preview.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a06b86a8c883318322ef4f39c8d2d7)